### PR TITLE
Add missing basics guides

### DIFF
--- a/learn/basics/delivery-mechanism-101.md
+++ b/learn/basics/delivery-mechanism-101.md
@@ -1,0 +1,93 @@
+# Your first Delivery Mechanism
+
+A delivery mechanism is whatever sits between the outside world and your use cases. It receives an external event — an HTTP request, a CLI command, a message off a queue — and translates it into a use case call.
+
+## The job of a delivery mechanism
+
+1. Translate the incoming request into use case input
+2. Call the use case
+3. Translate the use case response into an output
+
+That is all. A delivery mechanism contains no business logic and has no knowledge of gateways.
+
+## A simple example
+
+```ruby
+post '/orders' do
+  response = create_order.execute(
+    customer_id: params[:customer_id].to_i,
+    items: params[:items]
+  )
+
+  json(order_id: response[:order_id])
+end
+```
+
+The route knows about HTTP (params, JSON response). It does not know about `Order`, `OrderGateway`, or how `CreateOrder` works internally.
+
+## Extracting a controller class
+
+For anything beyond a trivial route, extract a controller class. This makes the delivery mechanism testable independently of the HTTP framework.
+
+```ruby
+module Delivery
+  class CreateOrderController
+    def initialize(create_order:)
+      @create_order = create_order
+    end
+
+    def execute(params, response)
+      result = @create_order.execute(
+        customer_id: params[:customer_id].to_i,
+        items: params[:items]
+      )
+      response.status = 201
+      response.body = { order_id: result[:order_id] }.to_json
+    end
+  end
+end
+```
+
+The controller has `create_order` injected as a collaborator, following the [constructors for collaborators](./constructors-for-collaborators.md) pattern. It is entirely unaware of how the use case is wired up or what gateway it uses.
+
+The Sinatra route becomes thin glue:
+
+```ruby
+post '/orders' do
+  controller = Delivery::CreateOrderController.new(
+    create_order: get_use_case(:create_order)
+  )
+  controller.execute(params, response)
+end
+```
+
+## Testing a delivery mechanism
+
+Because the controller accepts its use case as a dependency, you can test it in isolation by injecting a Stub:
+
+```ruby
+describe Delivery::CreateOrderController do
+  let(:create_order) { double('create_order', execute: { order_id: 42 }) }
+  let(:controller) { described_class.new(create_order: create_order) }
+
+  it 'sets a 201 status' do
+    response = double('response').as_null_object
+    controller.execute({ customer_id: '1', items: [] }, response)
+    expect(response).to have_received(:status=).with(201)
+  end
+end
+```
+
+No HTTP stack, no database, no real use case. Just the translation logic under test.
+
+## What must not live here
+
+- **Business logic**: if an order over £100 gets free shipping, that belongs in a use case or domain object
+- **Gateway knowledge**: the controller should not know what database you are using or how to construct one
+- **Authorisation rules**: covered separately in [Authorisation](../../intermediate/authorisation.md)
+
+## From the trenches
+
+The most common mistake is letting the delivery mechanism grow. It starts with a small conditional — "if the user is an admin, show a slightly different response" — and within a few months the controller is 200 lines and contains half your business rules.
+
+Keep delivery mechanisms so thin that there is almost nothing left to test. If you find yourself writing complex setup for a controller test, the logic probably belongs in a use case.

--- a/learn/basics/do-not-leak-your-internals.md
+++ b/learn/basics/do-not-leak-your-internals.md
@@ -60,4 +60,4 @@ A common scenario: you refactor `Order` to rename `customer_id` to `customer`. Y
 
 Had the use cases returned plain hashes, the change would have been contained inside the use case and gateway. The callers would have been untouched.
 
-The cost of the refactor just went from one file to six.
+The cost of the refactor just went from one file to six. Every additional file that needs to change is another opportunity to introduce a defect — a missed reference, a wrong field name, a test that was updated incorrectly and now passes for the wrong reason. The more code that moves, the more likely something breaks.

--- a/learn/basics/do-not-leak-your-internals.md
+++ b/learn/basics/do-not-leak-your-internals.md
@@ -1,0 +1,63 @@
+# Don't leak your internals!
+
+Use cases sit at the boundary of your application. Anything that crosses that boundary — both coming in and going out — should be a plain data structure.
+
+This rule is easy to follow for inputs (a hash of parameters). It is tempting to break for outputs — especially when you have a domain object sitting right there.
+
+## What leaking looks like
+
+A use case that returns a domain object:
+
+```ruby
+class PlaceOrder
+  def initialize(order_gateway:)
+    @order_gateway = order_gateway
+  end
+
+  def execute(customer_id:, items:)
+    order = Order.new(customer_id: customer_id, items: items)
+    @order_gateway.save(order)
+    order  # leaking a domain object
+  end
+end
+```
+
+The caller — a controller, a test, another use case — now has a direct dependency on `Order`. That means:
+
+- It can call any method on `Order`, including ones you didn't intend to expose
+- Any change to `Order`'s interface (method names, return types) can break callers silently
+- Your acceptance tests will start to know about internals they have no business knowing about
+
+## What not leaking looks like
+
+Return a plain hash instead:
+
+```ruby
+class PlaceOrder
+  def initialize(order_gateway:)
+    @order_gateway = order_gateway
+  end
+
+  def execute(customer_id:, items:)
+    order = Order.new(customer_id: customer_id, items: items)
+    id = @order_gateway.save(order)
+    { order_id: id }
+  end
+end
+```
+
+The caller gets back only what they need. The fact that an `Order` domain object exists is a private detail.
+
+## Why this matters
+
+The use case boundary is a seam. Everything on the outside of that seam — delivery mechanisms, acceptance tests, other use cases — should be able to change independently of everything on the inside.
+
+When a domain object escapes, that seam is broken. You lose the ability to refactor your domain freely.
+
+## From the trenches
+
+A common scenario: you refactor `Order` to rename `customer_id` to `customer`. You grep for `customer_id` to find all usages. You find it in three acceptance tests, two controllers, and an email formatter — none of which should know anything about `Order`.
+
+Had the use cases returned plain hashes, the change would have been contained inside the use case and gateway. The callers would have been untouched.
+
+The cost of the refactor just went from one file to six.

--- a/learn/basics/gateway-101.md
+++ b/learn/basics/gateway-101.md
@@ -12,44 +12,55 @@ That is the full extent of its responsibility. Business logic does not belong he
 
 ## Implementing the adapter
 
-Here is a simple ActiveRecord gateway for orders:
+The [Sequel](https://sequel.jeremyevans.net/) gem is a good fit for Clean Architecture in Ruby. Unlike ActiveRecord, Sequel keeps your database logic and your domain objects separate by default — there is no temptation to inherit from a base class and pull in persistence concerns.
+
+Here is a Sequel gateway for orders:
 
 ```ruby
-class ActiveRecordOrderGateway
+class SequelOrderGateway
+  def initialize(db)
+    @orders = db[:orders]
+    @line_items = db[:line_items]
+  end
+
   def save(customer_id:, items:)
-    record = OrderRecord.create!(
-      customer_id: customer_id,
-      line_items: items.to_json
-    )
-    record.id
+    id = @orders.insert(customer_id: customer_id)
+    items.each do |item|
+      @line_items.insert(order_id: id, sku: item[:sku], quantity: item[:quantity])
+    end
+    id
   end
 
   def find_by_id(id)
-    record = OrderRecord.find(id)
+    order = @orders.where(id: id).first
+    return nil unless order
+
+    items = @line_items.where(order_id: id).map do |row|
+      { sku: row[:sku], quantity: row[:quantity] }
+    end
+
     {
-      id: record.id,
-      customer_id: record.customer_id,
-      items: JSON.parse(record.line_items, symbolize_names: true)
+      id: order[:id],
+      customer_id: order[:customer_id],
+      items: items
     }
   end
 end
 ```
 
-The use case knows nothing about `OrderRecord`, `to_json`, or ActiveRecord. That is the point.
+The use case knows nothing about Sequel, table names, or how items are stored. That is the point.
 
 ## Keep the gateway thin
 
-It is tempting — especially with ActiveRecord — to let logic creep in:
+The gateway's job is persistence, not policy. Validation and rules belong in your use case or domain:
 
 ```ruby
 # Don't do this
 def save(customer_id:, items:)
   raise 'No items' if items.empty?   # business logic — belongs in the use case
-  OrderRecord.create!(...)
+  @orders.insert(...)
 end
 ```
-
-Validation and rules belong in your use case or domain. The gateway's job is persistence, not policy.
 
 ## Testing your Real Gateway
 
@@ -58,8 +69,8 @@ Gateway tests are integration tests — they run against a real database instanc
 Run the [shared contract](./reliable-dependencies.md) against your real gateway first:
 
 ```ruby
-describe ActiveRecordOrderGateway do
-  subject { ActiveRecordOrderGateway.new }
+describe SequelOrderGateway do
+  subject { SequelOrderGateway.new(DB) }
   it_behaves_like 'an order gateway'
 end
 ```
@@ -67,7 +78,7 @@ end
 Once the contract passes, add gateway-specific tests for edge cases the contract does not cover:
 
 ```ruby
-describe ActiveRecordOrderGateway do
+describe SequelOrderGateway do
   describe '#find_by_id' do
     context 'when the order does not exist' do
       it 'returns nil' do
@@ -85,3 +96,31 @@ Keep gateway integration tests in a separate suite from your unit tests. The inn
 When you replace the Fake with the real gateway, only your wiring changes — the place where you construct use cases and inject dependencies. Use cases, domain objects, and acceptance tests remain untouched.
 
 This is the payoff of keeping the gateway behind a consistent interface from the start.
+
+## A note on Rails
+
+### Tableless models in the delivery mechanism
+
+If you are building a Rails application, one option is to use tableless ActiveRecord objects in your delivery mechanism for form objects and parameter handling — giving you Rails conventions (validations, strong parameters) at the HTTP boundary without ActiveRecord objects leaking into your use cases.
+
+```ruby
+class OrderForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :customer_id, :integer
+  attribute :items, default: []
+
+  validates :customer_id, presence: true
+end
+```
+
+The form object lives in the delivery mechanism. Your use case receives a plain hash, as always.
+
+### Rails and Clean Architecture work against each other
+
+That said, using Rails with Clean Architecture is likely to lead to framework frustration. Rails is designed around the Active Record pattern and convention over configuration — a tight coupling between your domain model and your persistence layer is a feature, not a bug, in Rails' worldview.
+
+Clean Architecture pulls in exactly the opposite direction: keep your domain free of persistence concerns, defer technology choices, and make frameworks replaceable.
+
+Attempting both at once means fighting Rails' conventions at every turn. You will find yourself working around the framework rather than with it. For greenfield projects, a lighter framework — Sinatra, Hanami, or Roda — will create far less friction with a Clean Architecture approach.

--- a/learn/basics/gateway-101.md
+++ b/learn/basics/gateway-101.md
@@ -1,0 +1,87 @@
+# Your first Real Gateway
+
+Once you understand the domain well enough — and your acceptance tests are passing with a Fake — it is time to replace the Fake with a gateway that talks to a real persistence store.
+
+## What a Real Gateway does
+
+A gateway is responsible for one thing: translating between the language of your domain and the language of your storage technology.
+
+It converts a domain-friendly request into whatever the database expects, and converts what the database returns into a plain hash that the use case can work with.
+
+That is the full extent of its responsibility. Business logic does not belong here.
+
+## Implementing the adapter
+
+Here is a simple ActiveRecord gateway for orders:
+
+```ruby
+class ActiveRecordOrderGateway
+  def save(customer_id:, items:)
+    record = OrderRecord.create!(
+      customer_id: customer_id,
+      line_items: items.to_json
+    )
+    record.id
+  end
+
+  def find_by_id(id)
+    record = OrderRecord.find(id)
+    {
+      id: record.id,
+      customer_id: record.customer_id,
+      items: JSON.parse(record.line_items, symbolize_names: true)
+    }
+  end
+end
+```
+
+The use case knows nothing about `OrderRecord`, `to_json`, or ActiveRecord. That is the point.
+
+## Keep the gateway thin
+
+It is tempting — especially with ActiveRecord — to let logic creep in:
+
+```ruby
+# Don't do this
+def save(customer_id:, items:)
+  raise 'No items' if items.empty?   # business logic — belongs in the use case
+  OrderRecord.create!(...)
+end
+```
+
+Validation and rules belong in your use case or domain. The gateway's job is persistence, not policy.
+
+## Testing your Real Gateway
+
+Gateway tests are integration tests — they run against a real database instance, not a Fake. This is correct and expected.
+
+Run the [shared contract](./reliable-dependencies.md) against your real gateway first:
+
+```ruby
+describe ActiveRecordOrderGateway do
+  subject { ActiveRecordOrderGateway.new }
+  it_behaves_like 'an order gateway'
+end
+```
+
+Once the contract passes, add gateway-specific tests for edge cases the contract does not cover:
+
+```ruby
+describe ActiveRecordOrderGateway do
+  describe '#find_by_id' do
+    context 'when the order does not exist' do
+      it 'returns nil' do
+        expect(subject.find_by_id(99999)).to be_nil
+      end
+    end
+  end
+end
+```
+
+Keep gateway integration tests in a separate suite from your unit tests. The inner TDD loop depends on fast feedback — gateway tests are slower by nature and should not slow down every red-green cycle.
+
+## Swapping in the real gateway
+
+When you replace the Fake with the real gateway, only your wiring changes — the place where you construct use cases and inject dependencies. Use cases, domain objects, and acceptance tests remain untouched.
+
+This is the payoff of keeping the gateway behind a consistent interface from the start.

--- a/learn/basics/reliable-dependencies.md
+++ b/learn/basics/reliable-dependencies.md
@@ -1,0 +1,73 @@
+# Build in a reliable dependency upgrade path
+
+Fake gateways let you build and test your application without a real database. But there is a risk: your Fake can drift from the real thing.
+
+If the Fake behaves differently to the real gateway, your test suite will pass while your application fails in production. This is the worst kind of test failure — the invisible one.
+
+## The problem
+
+Imagine your `InMemoryOrderGateway` returns orders sorted by insertion order. Your real `ActiveRecordOrderGateway` returns them sorted by `created_at` descending.
+
+Your acceptance tests pass. Your production app shows orders in the wrong order.
+
+The Fake lied.
+
+## Gateway contracts
+
+The solution is to write a shared contract: a set of tests that both your Fake and your real gateway must pass.
+
+In RSpec, this is done with `shared_examples`:
+
+```ruby
+RSpec.shared_examples 'an order gateway' do
+  it 'saves and retrieves an order by id' do
+    id = subject.save(customer_id: 1, items: [])
+    order = subject.find_by_id(id)
+    expect(order[:customer_id]).to eq(1)
+  end
+
+  it 'returns orders in reverse chronological order' do
+    subject.save(customer_id: 1, items: [])
+    subject.save(customer_id: 2, items: [])
+    orders = subject.all
+    expect(orders.first[:customer_id]).to eq(2)
+  end
+end
+```
+
+Both gateways include the contract:
+
+```ruby
+describe InMemoryOrderGateway do
+  subject { InMemoryOrderGateway.new }
+  it_behaves_like 'an order gateway'
+end
+
+describe ActiveRecordOrderGateway do
+  subject { ActiveRecordOrderGateway.new }
+  it_behaves_like 'an order gateway'
+end
+```
+
+Now the Fake is contractually obligated to behave the same way as the real gateway. If either drifts, the contract tests catch it.
+
+## What the contract should cover
+
+- The interface: what methods exist, what they accept, what they return
+- The semantics: ordering, uniqueness constraints, what happens when a record is not found
+
+The contract does not need to test every edge case — that is the job of the real gateway's own integration tests. It only needs to cover the behaviour your use cases depend on.
+
+## The upgrade path
+
+When you introduce a new persistence technology — say, replacing ActiveRecord with a raw SQL gateway — you:
+
+1. Implement the new gateway
+2. Run the contract tests against it
+3. If they pass, swap it in
+
+Your use cases, domain objects, and acceptance tests require no changes. The contract tests are your safety net.
+
+## From the trenches
+
+A Fake is a working implementation with shortcuts. That "working" part is the obligation — it must faithfully represent the behaviour of the real thing within the contract. Shared contract tests are how you enforce that obligation and ensure the shortcuts never become lies.

--- a/learn/basics/tdd-everything.md
+++ b/learn/basics/tdd-everything.md
@@ -1,0 +1,95 @@
+# TDD everything
+
+The [outer loop](./fake-gateways.md) describes an ATDD discipline: write a failing acceptance test, make it pass, repeat. But the outer loop does not tell you how to write the production code in between.
+
+That is what the inner loop is for.
+
+## The inner loop
+
+When your acceptance test is failing, you enter the inner loop:
+
+1. Write a failing unit test
+2. Watch it fail for the right reason
+3. Write the minimum production code to make it pass
+4. Watch it pass
+5. Refactor
+6. Does the acceptance test pass? If yes, go back to the outer loop. If no, go back to step 1.
+
+## The three rules
+
+The inner loop is governed by three rules:
+
+1. You **must** write a failing test before writing any production code
+2. You **must not** write more of a test than is sufficient to fail
+3. You **must not** write more production code than is sufficient to make the currently failing test pass
+
+Rule 3 permits sliming — returning a hardcoded value to make a test pass. This is not cheating. It is a signal: you don't yet have enough tests to justify writing the real implementation. Triangulation closes this loophole.
+
+## Triangulation
+
+With a single test, you can pass it by hardcoding the expected value:
+
+```ruby
+def total_price(items)
+  10.00
+end
+```
+
+Write a second test with different input and a different expected output. Now you are forced to write the real implementation.
+
+Only generalise production code when a failing test demands it.
+
+## Arrange, Act, Assert, Teardown
+
+Every unit test follows this structure:
+
+- **Arrange** — set up the state required for the test
+- **Act** — call the thing under test
+- **Assert** — verify the outcome
+- **Teardown** — clean up (often handled automatically)
+
+Name your tests to describe the behaviour of the software from the user's perspective, not the implementation. `"#execute"` is not a useful test name. `"returns the order total including tax"` is.
+
+```ruby
+describe 'placing an order' do
+  context 'given a single item' do
+    it 'returns the order id' do
+      # Arrange
+      order_gateway = InMemoryOrderGateway.new
+      place_order = PlaceOrder.new(order_gateway: order_gateway)
+
+      # Act
+      response = place_order.execute(customer_id: 1, items: [{ sku: 'ABC', quantity: 1 }])
+
+      # Assert
+      expect(response[:order_id]).not_to be_nil
+    end
+  end
+end
+```
+
+## Test doubles at the unit level
+
+When unit testing a use case, inject a [Fake](./fake-gateways.md) to stand in for real gateways. This keeps tests fast and focused on use case behaviour only.
+
+The five types of test double are Dummy, Stub, Fake, Spy, and True Mock. At the use case level, Fakes are most common — they are working implementations with shortcuts (in-memory instead of a database). Stubs work well for simpler cases where you only need to control a return value.
+
+Minimise the number of test doubles in a single test. A test that needs three mocked collaborators to arrange is a signal that the class under test has too many responsibilities.
+
+## Well-designed tests
+
+Avoid tight coupling between test code and production code. The goal is for your production code's public interface to be able to evolve without requiring you to rewrite tests.
+
+Asserting on implementation details rather than observable behaviour creates churn: every internal refactor that _should not_ break anything ends up breaking tests.
+
+## When TDD is not appropriate
+
+Not everything should be TDD'd:
+
+- **Markup** (HTML, templates): correctness can only be verified by visual inspection
+- **Configuration**: config files and state machines are only testable by running them against the real system they configure
+- **Slow feedback cycles**: if your test cycle takes minutes per iteration, weigh the cost carefully — but invest in making feedback faster rather than abandoning TDD
+
+## Keep feedback fast
+
+Aim for individual unit test suites to run in under 30 seconds. A slow unit test suite is usually a structural problem — unit tests that hit a real database or real external services. Keep those in a separate integration suite, and keep the inner loop fast.


### PR DESCRIPTION
## Summary

- Adds the 5 missing basics guides referenced in the README but not yet written
- Each guide follows the established style: concrete Ruby examples, \"From the trenches\" sidebars, focus on the \"why\" not just the \"what\"
- TDD guide draws on the [Made Tech TDD core skill](https://learn.madetech.com/technology/core-skills/tdd/) and is scoped to the inner loop only (the outer ATDD loop is already covered in `fake-gateways.md`)

## Guides added

| File | Title |
|------|-------|
| `learn/basics/do-not-leak-your-internals.md` | Don't leak your internals! |
| `learn/basics/tdd-everything.md` | TDD everything |
| `learn/basics/reliable-dependencies.md` | Build in a reliable dependency upgrade path |
| `learn/basics/gateway-101.md` | Your first Real Gateway |
| `learn/basics/delivery-mechanism-101.md` | Your first Delivery Mechanism |

## Test plan

- [ ] Read each guide end-to-end for tone and consistency with existing basics guides
- [ ] Check all internal links resolve correctly
- [ ] Verify Ruby code examples are syntactically correct
- [ ] Confirm the TDD guide does not duplicate the outer loop content from `fake-gateways.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)