### PR TITLE
Add missing intermediate guides

### DIFF
--- a/learn/intermediate/authentication.md
+++ b/learn/intermediate/authentication.md
@@ -83,7 +83,9 @@ before do
 end
 ```
 
-Use cases that need to know who is acting receive the actor's identity as plain input data:
+### Passing the current user as input
+
+The simplest approach is to pass the actor's identity as a parameter to `execute`:
 
 ```ruby
 post '/orders' do
@@ -96,6 +98,77 @@ end
 ```
 
 The use case has no knowledge of tokens, headers, or sessions. It receives an ID and treats it as a fact.
+
+### Providing the current user as a gateway
+
+When many use cases in a system need to know who the current user is, threading `current_user_id:` through every `execute` call becomes noisy. An alternative is to provide the current user as a constructor dependency — the same pattern used for gateways.
+
+Define a simple current user object:
+
+```ruby
+class CurrentUser
+  attr_reader :id
+
+  def initialize(id)
+    @id = id
+  end
+end
+```
+
+Inject it into use cases that need it:
+
+```ruby
+class PlaceOrder
+  def initialize(order_gateway:, current_user:)
+    @order_gateway = order_gateway
+    @current_user = current_user
+  end
+
+  def execute(items:)
+    id = @order_gateway.save(customer_id: @current_user.id, items: items)
+    { order_id: id }
+  end
+end
+```
+
+The delivery mechanism constructs the `CurrentUser` after authentication and passes it into the [dependency factory](./keep-your-wiring-DRY.md):
+
+```ruby
+before do
+  # ... token verification ...
+  @current_user = CurrentUser.new(session[:user_id])
+end
+
+post '/orders' do
+  result = get_use_case(:place_order).execute(items: params[:items])
+  json(result)
+end
+```
+
+```ruby
+class Dependencies
+  def initialize(db:, current_user:)
+    @db = db
+    @current_user = current_user
+  end
+
+  def get_use_case(name)
+    case name
+    when :place_order
+      PlaceOrder.new(order_gateway: order_gateway, current_user: @current_user)
+    end
+  end
+end
+```
+
+In tests, inject a `CurrentUser` directly — no token, no session, no HTTP:
+
+```ruby
+let(:current_user) { CurrentUser.new(1) }
+let(:use_case) { PlaceOrder.new(order_gateway: InMemoryOrderGateway.new, current_user: current_user) }
+```
+
+Both approaches keep the use case free of authentication concerns. Choose whichever keeps the `execute` interface cleaner for your system.
 
 ## What must not live in the use case
 

--- a/learn/intermediate/authentication.md
+++ b/learn/intermediate/authentication.md
@@ -1,0 +1,136 @@
+# Authentication
+
+Authentication is the act of verifying identity: confirming that the person or system making a request is who they claim to be.
+
+In Clean Architecture, authentication fits naturally as a use case backed by a gateway. The delivery mechanism handles the mechanics of extracting credentials from a request; the use case verifies them.
+
+## Authentication as a use case
+
+```ruby
+class AuthenticateUser
+  def initialize(user_gateway:, session_gateway:)
+    @user_gateway = user_gateway
+    @session_gateway = session_gateway
+  end
+
+  def execute(email:, password:)
+    user = @user_gateway.find_by_email(email)
+    return { success: false, errors: [:invalid_credentials] } unless user
+    return { success: false, errors: [:invalid_credentials] } unless valid_password?(user, password)
+
+    token = @session_gateway.create(user_id: user[:id])
+    { success: true, token: token }
+  end
+
+  private
+
+  def valid_password?(user, password)
+    BCrypt::Password.new(user[:password_digest]) == password
+  end
+end
+```
+
+Note that the use case returns the same error (`:invalid_credentials`) whether the email is unrecognised or the password is wrong. This is deliberate — distinguishing the two would allow an attacker to enumerate valid email addresses.
+
+## Sessions are a gateway concern
+
+A session token is persisted state — it belongs in a gateway:
+
+```ruby
+class SequelSessionGateway
+  TOKEN_EXPIRY_SECONDS = 86_400
+
+  def initialize(db)
+    @sessions = db[:sessions]
+  end
+
+  def create(user_id:)
+    token = SecureRandom.hex(32)
+    @sessions.insert(
+      token: token,
+      user_id: user_id,
+      expires_at: Time.now + TOKEN_EXPIRY_SECONDS
+    )
+    token
+  end
+
+  def find_by_token(token)
+    @sessions.where(token: token).where { expires_at > Time.now }.first
+  end
+
+  def delete(token:)
+    @sessions.where(token: token).delete
+  end
+end
+```
+
+A `LogOutUser` use case would call `session_gateway.delete(token:)`. Expiry is enforced by the gateway — use cases do not need to reason about it.
+
+## The delivery mechanism handles credential extraction
+
+The delivery mechanism is responsible for extracting credentials from the transport layer (headers, cookies, form params) and for rejecting unauthenticated requests before they reach a use case:
+
+```ruby
+# Sinatra before filter
+before do
+  next if request.path_info == '/session'  # login route is public
+
+  token = request.env['HTTP_AUTHORIZATION']&.split(' ')&.last
+  session = session_gateway.find_by_token(token.to_s)
+  halt 401, json(errors: [:unauthenticated]) unless session
+
+  @current_user_id = session[:user_id]
+end
+```
+
+Use cases that need to know who is acting receive the actor's identity as plain input data:
+
+```ruby
+post '/orders' do
+  result = get_use_case(:place_order).execute(
+    customer_id: @current_user_id,
+    items: params[:items]
+  )
+  json(result)
+end
+```
+
+The use case has no knowledge of tokens, headers, or sessions. It receives an ID and treats it as a fact.
+
+## What must not live in the use case
+
+Business use cases should not verify tokens, check session expiry, or read from request headers. That is the delivery mechanism's responsibility.
+
+A use case that begins with `session = @session_gateway.find_by_token(token)` has taken on authentication as a side concern. Token verification is the same regardless of which use case is being called — it belongs in the layer that all requests pass through before reaching any use case.
+
+## Testing authentication
+
+The `AuthenticateUser` use case can be tested without HTTP or real sessions:
+
+```ruby
+describe AuthenticateUser do
+  let(:user_gateway) { InMemoryUserGateway.new }
+  let(:session_gateway) { InMemorySessionGateway.new }
+  let(:use_case) { described_class.new(user_gateway: user_gateway, session_gateway: session_gateway) }
+
+  before do
+    user_gateway.create(email: 'user@example.com', password: 'correct-password')
+  end
+
+  context 'with valid credentials' do
+    it 'returns a session token' do
+      result = use_case.execute(email: 'user@example.com', password: 'correct-password')
+      expect(result[:success]).to be(true)
+      expect(result[:token]).not_to be_nil
+    end
+  end
+
+  context 'with an incorrect password' do
+    it 'returns invalid_credentials' do
+      result = use_case.execute(email: 'user@example.com', password: 'wrong')
+      expect(result[:success]).to be(false)
+      expect(result[:errors]).to include(:invalid_credentials)
+    end
+  end
+end
+```

--- a/learn/intermediate/authorisation.md
+++ b/learn/intermediate/authorisation.md
@@ -1,0 +1,133 @@
+# Authorisation
+
+[Authentication](./authentication.md) answers "who are you?". Authorisation answers "what are you allowed to do?".
+
+They are distinct concerns and should live in distinct places.
+
+## Policy objects as domain objects
+
+Authorisation rules are domain knowledge. "A customer may only cancel their own orders, and only if the order is still pending" is a business rule — it belongs in the domain, not scattered across use cases or delivery mechanisms.
+
+Model it as a domain object:
+
+```ruby
+class OrderPolicy
+  def initialize(order:, actor_id:)
+    @order = order
+    @actor_id = actor_id
+  end
+
+  def can_cancel?
+    owns_order? && order_is_pending?
+  end
+
+  def can_view?
+    owns_order?
+  end
+
+  private
+
+  def owns_order?
+    @order[:customer_id] == @actor_id
+  end
+
+  def order_is_pending?
+    @order[:status] == 'pending'
+  end
+end
+```
+
+Policy objects are plain Ruby objects with no dependencies — they are among the easiest things in the system to test.
+
+## Enforcing authorisation inside the use case
+
+The use case enforces the policy after loading the relevant data:
+
+```ruby
+class CancelOrder
+  def initialize(order_gateway:)
+    @order_gateway = order_gateway
+  end
+
+  def execute(order_id:, actor_id:)
+    order = @order_gateway.find_by_id(order_id)
+    return { success: false, errors: [:order_not_found] } unless order
+
+    policy = OrderPolicy.new(order: order, actor_id: actor_id)
+    return { success: false, errors: [:not_authorised] } unless policy.can_cancel?
+
+    @order_gateway.cancel(order_id)
+    { success: true }
+  end
+end
+```
+
+The use case loads the record, checks the policy, and acts — in that order. The delivery mechanism need only pass the authenticated actor's ID.
+
+## Testing authorisation
+
+Test the policy object independently, without touching the use case or gateway:
+
+```ruby
+describe OrderPolicy do
+  describe '#can_cancel?' do
+    context 'when the actor owns the order and it is pending' do
+      it 'permits cancellation' do
+        order = { customer_id: 1, status: 'pending' }
+        expect(described_class.new(order: order, actor_id: 1).can_cancel?).to be(true)
+      end
+    end
+
+    context 'when the actor does not own the order' do
+      it 'denies cancellation' do
+        order = { customer_id: 1, status: 'pending' }
+        expect(described_class.new(order: order, actor_id: 2).can_cancel?).to be(false)
+      end
+    end
+
+    context 'when the order is not pending' do
+      it 'denies cancellation' do
+        order = { customer_id: 1, status: 'dispatched' }
+        expect(described_class.new(order: order, actor_id: 1).can_cancel?).to be(false)
+      end
+    end
+  end
+end
+```
+
+Test the use case separately, with a stub policy or by exercising the full flow through a fake gateway:
+
+```ruby
+describe CancelOrder do
+  let(:order_gateway) { InMemoryOrderGateway.new }
+  let(:use_case) { described_class.new(order_gateway: order_gateway) }
+
+  context 'when the actor does not own the order' do
+    it 'returns not_authorised' do
+      order_id = order_gateway.save(customer_id: 1, status: 'pending', items: [])
+      result = use_case.execute(order_id: order_id, actor_id: 2)
+      expect(result[:errors]).to include(:not_authorised)
+    end
+  end
+end
+```
+
+## What must not live in the delivery mechanism
+
+It is tempting to enforce authorisation in a `before` filter:
+
+```ruby
+# Avoid this
+before '/orders/:id/cancel' do
+  order = order_gateway.find_by_id(params[:id].to_i)
+  halt 403 unless order[:customer_id] == @current_user_id
+end
+```
+
+The problem is that the rule is now tied to an HTTP route. If the same action is later triggered by a background job, a CLI command, or another use case, the protection is missing. Authorisation logic in the delivery mechanism is only authorisation for that one delivery mechanism.
+
+Enforcing rules inside the use case means the protection travels with the business logic, regardless of how it is invoked.
+
+## From the trenches
+
+Authorisation rules have a habit of growing complex — roles, ownership, team membership, time-based restrictions. Policy objects accommodate this naturally: add methods, add tests, keep it out of use cases. A use case that contains twenty lines of authorisation logic before it does any real work is a sign the policy object is missing.

--- a/learn/intermediate/authorisation.md
+++ b/learn/intermediate/authorisation.md
@@ -4,31 +4,91 @@
 
 They are distinct concerns and should live in distinct places.
 
-## Policy objects as domain objects
+## The problem with authorisation inside use cases
 
-Authorisation rules are domain knowledge. "A customer may only cancel their own orders, and only if the order is still pending" is a business rule — it belongs in the domain, not scattered across use cases or delivery mechanisms.
+It is tempting to check permissions inside the use case itself:
 
-Model it as a domain object:
+```ruby
+class CancelOrder
+  def execute(order_id:, actor_id:)
+    order = @order_gateway.find_by_id(order_id)
+    return { success: false, errors: [:not_authorised] } unless order[:customer_id] == actor_id
+    @order_gateway.cancel(order_id)
+    { success: true }
+  end
+end
+```
+
+This works, but it mixes two concerns: "is this user allowed to cancel this order?" and "cancel the order". As authorisation rules grow — roles, team membership, time-based windows — the use case fills up with logic that has nothing to do with cancellation. Testing the cancellation logic also requires setting up authorisation scenarios.
+
+## The proxy pattern
+
+A cleaner approach is a proxy class that wraps the use case call. The proxy is solely responsible for authorisation. If the check passes, it delegates to the real use case. If not, it returns early. The real use case remains pure business logic.
+
+```ruby
+# The real use case — knows nothing about who is allowed to call it
+class CancelOrder
+  def initialize(order_gateway:)
+    @order_gateway = order_gateway
+  end
+
+  def execute(order_id:)
+    @order_gateway.cancel(order_id)
+    { success: true }
+  end
+end
+```
+
+```ruby
+# The proxy — responsible only for authorisation
+class AuthorisedCancelOrder
+  def initialize(cancel_order:, order_gateway:, current_user:)
+    @cancel_order = cancel_order
+    @order_gateway = order_gateway
+    @current_user = current_user
+  end
+
+  def execute(order_id:)
+    order = @order_gateway.find_by_id(order_id)
+    policy = OrderPolicy.new(order: order, current_user: @current_user)
+    return { success: false, errors: [:not_authorised] } unless policy.can_cancel?
+
+    @cancel_order.execute(order_id: order_id)
+  end
+end
+```
+
+Note that the proxy returns `:not_authorised` whether the order does not exist or the actor lacks permission. This is intentional — returning `:not_found` for a missing resource leaks information about what exists in the system.
+
+The proxy has the same interface as the use case it wraps: it responds to `execute`. From the delivery mechanism's perspective, they are interchangeable.
+
+## Policy objects
+
+Policy objects hold the authorisation rules. They are only ever evaluated by proxy classes — not by use cases, not by delivery mechanisms.
+
+The policy receives the data it needs to make a decision and the `CurrentUser` that provides actor context (introduced in [Authentication](./authentication.md)):
 
 ```ruby
 class OrderPolicy
-  def initialize(order:, actor_id:)
+  def initialize(order:, current_user:)
     @order = order
-    @actor_id = actor_id
+    @current_user = current_user
   end
 
   def can_cancel?
+    return false unless @order
     owns_order? && order_is_pending?
   end
 
   def can_view?
+    return false unless @order
     owns_order?
   end
 
   private
 
   def owns_order?
-    @order[:customer_id] == @actor_id
+    @order[:customer_id] == @current_user.id
   end
 
   def order_is_pending?
@@ -37,36 +97,44 @@ class OrderPolicy
 end
 ```
 
-Policy objects are plain Ruby objects with no dependencies — they are among the easiest things in the system to test.
+Policy objects are plain Ruby with no dependencies — they are among the easiest things in the system to test.
 
-## Enforcing authorisation inside the use case
+## Wiring via the dependency factory
 
-The use case enforces the policy after loading the relevant data:
+The [dependency factory](./keep-your-wiring-DRY.md) composes the proxy around the use case transparently. The delivery mechanism requests `:cancel_order` and receives whatever is registered — proxy included:
 
 ```ruby
-class CancelOrder
-  def initialize(order_gateway:)
-    @order_gateway = order_gateway
+class Dependencies
+  def initialize(db:, current_user:)
+    @db = db
+    @current_user = current_user
   end
 
-  def execute(order_id:, actor_id:)
-    order = @order_gateway.find_by_id(order_id)
-    return { success: false, errors: [:order_not_found] } unless order
-
-    policy = OrderPolicy.new(order: order, actor_id: actor_id)
-    return { success: false, errors: [:not_authorised] } unless policy.can_cancel?
-
-    @order_gateway.cancel(order_id)
-    { success: true }
+  def get_use_case(name)
+    case name
+    when :cancel_order
+      AuthorisedCancelOrder.new(
+        cancel_order: CancelOrder.new(order_gateway: order_gateway),
+        order_gateway: order_gateway,
+        current_user: @current_user
+      )
+    end
   end
 end
 ```
 
-The use case loads the record, checks the policy, and acts — in that order. The delivery mechanism need only pass the authenticated actor's ID.
+The delivery mechanism is completely unaware that a proxy exists:
 
-## Testing authorisation
+```ruby
+delete '/orders/:id' do
+  result = get_use_case(:cancel_order).execute(order_id: params[:id].to_i)
+  json(result)
+end
+```
 
-Test the policy object independently, without touching the use case or gateway:
+## Testing each layer independently
+
+Test the policy in isolation — no gateways, no use cases:
 
 ```ruby
 describe OrderPolicy do
@@ -74,39 +142,75 @@ describe OrderPolicy do
     context 'when the actor owns the order and it is pending' do
       it 'permits cancellation' do
         order = { customer_id: 1, status: 'pending' }
-        expect(described_class.new(order: order, actor_id: 1).can_cancel?).to be(true)
+        current_user = CurrentUser.new(1)
+        expect(described_class.new(order: order, current_user: current_user).can_cancel?).to be(true)
       end
     end
 
     context 'when the actor does not own the order' do
       it 'denies cancellation' do
         order = { customer_id: 1, status: 'pending' }
-        expect(described_class.new(order: order, actor_id: 2).can_cancel?).to be(false)
+        current_user = CurrentUser.new(2)
+        expect(described_class.new(order: order, current_user: current_user).can_cancel?).to be(false)
       end
     end
 
     context 'when the order is not pending' do
       it 'denies cancellation' do
         order = { customer_id: 1, status: 'dispatched' }
-        expect(described_class.new(order: order, actor_id: 1).can_cancel?).to be(false)
+        current_user = CurrentUser.new(1)
+        expect(described_class.new(order: order, current_user: current_user).can_cancel?).to be(false)
       end
     end
   end
 end
 ```
 
-Test the use case separately, with a stub policy or by exercising the full flow through a fake gateway:
+Test the use case with no authorisation concerns at all:
 
 ```ruby
 describe CancelOrder do
   let(:order_gateway) { InMemoryOrderGateway.new }
-  let(:use_case) { described_class.new(order_gateway: order_gateway) }
+  subject { described_class.new(order_gateway: order_gateway) }
+
+  it 'cancels the order' do
+    order_id = order_gateway.save(customer_id: 1, status: 'pending', items: [])
+    result = subject.execute(order_id: order_id)
+    expect(result[:success]).to be(true)
+  end
+end
+```
+
+Test the proxy with a stub inner use case to verify it enforces the policy and delegates correctly:
+
+```ruby
+describe AuthorisedCancelOrder do
+  let(:inner_use_case) { double(:cancel_order, execute: { success: true }) }
+  let(:order_gateway) { InMemoryOrderGateway.new }
+  let(:current_user) { CurrentUser.new(1) }
+
+  subject do
+    described_class.new(
+      cancel_order: inner_use_case,
+      order_gateway: order_gateway,
+      current_user: current_user
+    )
+  end
+
+  context 'when the actor owns a pending order' do
+    it 'delegates to the inner use case' do
+      order_id = order_gateway.save(customer_id: 1, status: 'pending', items: [])
+      subject.execute(order_id: order_id)
+      expect(inner_use_case).to have_received(:execute).with(order_id: order_id)
+    end
+  end
 
   context 'when the actor does not own the order' do
-    it 'returns not_authorised' do
-      order_id = order_gateway.save(customer_id: 1, status: 'pending', items: [])
-      result = use_case.execute(order_id: order_id, actor_id: 2)
+    it 'returns not_authorised without delegating' do
+      order_id = order_gateway.save(customer_id: 2, status: 'pending', items: [])
+      result = subject.execute(order_id: order_id)
       expect(result[:errors]).to include(:not_authorised)
+      expect(inner_use_case).not_to have_received(:execute)
     end
   end
 end
@@ -124,10 +228,10 @@ before '/orders/:id/cancel' do
 end
 ```
 
-The problem is that the rule is now tied to an HTTP route. If the same action is later triggered by a background job, a CLI command, or another use case, the protection is missing. Authorisation logic in the delivery mechanism is only authorisation for that one delivery mechanism.
+The rule is now tied to an HTTP route. If the same action is triggered by a background job, a CLI command, or another use case, the protection is absent. Authorisation in the delivery mechanism is only authorisation for that one delivery mechanism.
 
-Enforcing rules inside the use case means the protection travels with the business logic, regardless of how it is invoked.
+The proxy pattern ensures the protection travels with the use case, regardless of how it is invoked.
 
 ## From the trenches
 
-Authorisation rules have a habit of growing complex — roles, ownership, team membership, time-based restrictions. Policy objects accommodate this naturally: add methods, add tests, keep it out of use cases. A use case that contains twenty lines of authorisation logic before it does any real work is a sign the policy object is missing.
+As authorisation rules grow complex — roles, team membership, time-based windows — additional policy methods and proxy classes absorb that complexity cleanly. A use case that has grown twenty lines of permission checks before doing any real work is a signal the proxy is missing.

--- a/learn/intermediate/extend-with-domain.md
+++ b/learn/intermediate/extend-with-domain.md
@@ -221,20 +221,51 @@ describe WholesaleCustomer do
 end
 ```
 
-The fake gateway shares `TIER_CONSTRUCTORS` with the real gateway so the same domain object types are exercised in tests and production:
+### Extracting a Builder
+
+The fake gateway needs access to the same construction logic as the real gateway. The approach above of referencing `SequelCustomerGateway::TIER_CONSTRUCTORS` directly creates a dependency from the fake onto the real — the fake now knows about a specific persistence implementation it should be unaware of.
+
+Extract the construction logic into a dedicated builder:
 
 ```ruby
+class CustomerBuilder
+  CONSTRUCTORS = {
+    'standard'  => ->(row) { StandardCustomer.new },
+    'premium'   => ->(row) { PremiumCustomer.new },
+    'wholesale' => ->(row) { WholesaleCustomer.new(account_manager_id: row[:account_manager_id]) }
+  }.freeze
+
+  def self.build(row)
+    constructor = CONSTRUCTORS.fetch(row[:tier], CONSTRUCTORS['standard'])
+    constructor.call(row)
+  end
+end
+```
+
+Both the real and fake gateway delegate to the builder — neither owns the construction logic, and neither depends on the other:
+
+```ruby
+class SequelCustomerGateway
+  def find(id)
+    row = @customers.where(id: id).first
+    CustomerBuilder.build(row)
+  end
+end
+
 class InMemoryCustomerGateway
   def find(id)
     @customers[id]
   end
 
-  def save(id:, tier:, **attrs)
-    constructor = SequelCustomerGateway::TIER_CONSTRUCTORS.fetch(tier, SequelCustomerGateway::TIER_CONSTRUCTORS['standard'])
-    @customers[id] = constructor.call(attrs)
+  def save(id:, **attrs)
+    @customers[id] = CustomerBuilder.build(attrs)
   end
 end
 ```
+
+Adding a new tier now means: a new domain class, one new entry in `CustomerBuilder::CONSTRUCTORS`. Nothing else changes — not the real gateway, not the fake, not any use case.
+
+The builder can also be tested independently to verify it produces the right type for each tier value.
 
 ## The guiding question
 

--- a/learn/intermediate/extend-with-domain.md
+++ b/learn/intermediate/extend-with-domain.md
@@ -161,26 +161,34 @@ class PremiumCustomer
 end
 
 class WholesaleCustomer
+  def initialize(account_manager_id:)
+    @account_manager_id = account_manager_id
+  end
+
   def discount_rate
     0.6
   end
 end
 ```
 
-The gateway reads the `tier` column and constructs the right type:
+The gateway reads the `tier` column and constructs the right type. Two style points matter here:
+
+**Prefer a lookup hash over a case statement.** A case statement requires modifying existing code to add a new branch — it is closed to extension. A lookup hash is open to extension: adding a new tier means adding one entry to the hash, leaving existing entries untouched. It is also easier to scan.
+
+**Use constructor lambdas rather than calling `.new` on the class directly.** Different domain object types may have different constructor parameters — `WholesaleCustomer` needs an `account_manager_id` that `StandardCustomer` does not. Storing lambdas instead of classes keeps the call site uniform (`constructor.call(row)`) while letting each lambda pass exactly the data its type requires.
 
 ```ruby
 class SequelCustomerGateway
-  TIER_CLASSES = {
-    'standard'  => StandardCustomer,
-    'premium'   => PremiumCustomer,
-    'wholesale' => WholesaleCustomer
+  TIER_CONSTRUCTORS = {
+    'standard'  => ->(row) { StandardCustomer.new },
+    'premium'   => ->(row) { PremiumCustomer.new },
+    'wholesale' => ->(row) { WholesaleCustomer.new(account_manager_id: row[:account_manager_id]) }
   }.freeze
 
   def find(id)
     row = @customers.where(id: id).first
-    tier_class = TIER_CLASSES.fetch(row[:tier], StandardCustomer)
-    tier_class.new
+    constructor = TIER_CONSTRUCTORS.fetch(row[:tier], TIER_CONSTRUCTORS['standard'])
+    constructor.call(row)
   end
 end
 ```
@@ -199,7 +207,7 @@ class PlaceOrder
 end
 ```
 
-Adding a `VipCustomer` with a 50% discount rate requires a new class and one new line in the gateway's mapping. The use case, the `UpdateOrder` use case, and any other use case that prices orders are untouched.
+Adding a `VipCustomer` with a 50% discount rate requires a new class and one new entry in `TIER_CONSTRUCTORS`. The use case, `UpdateOrder`, and any other use case that prices orders are untouched.
 
 ### Testing
 
@@ -208,12 +216,12 @@ Each domain class is trivial to test in isolation:
 ```ruby
 describe WholesaleCustomer do
   it 'has a 40% discount rate' do
-    expect(described_class.new.discount_rate).to eq(0.6)
+    expect(described_class.new(account_manager_id: 1).discount_rate).to eq(0.6)
   end
 end
 ```
 
-The fake gateway used in acceptance tests can return domain objects by type directly, without a database:
+The fake gateway shares `TIER_CONSTRUCTORS` with the real gateway so the same domain object types are exercised in tests and production:
 
 ```ruby
 class InMemoryCustomerGateway
@@ -221,14 +229,12 @@ class InMemoryCustomerGateway
     @customers[id]
   end
 
-  def save(id:, tier:)
-    tier_class = SequelCustomerGateway::TIER_CLASSES.fetch(tier, StandardCustomer)
-    @customers[id] = tier_class.new
+  def save(id:, tier:, **attrs)
+    constructor = SequelCustomerGateway::TIER_CONSTRUCTORS.fetch(tier, SequelCustomerGateway::TIER_CONSTRUCTORS['standard'])
+    @customers[id] = constructor.call(attrs)
   end
 end
 ```
-
-By sharing the `TIER_CLASSES` mapping with the real gateway, the fake stays honest — the same domain object types are exercised in tests and production.
 
 ## The guiding question
 

--- a/learn/intermediate/extend-with-domain.md
+++ b/learn/intermediate/extend-with-domain.md
@@ -117,8 +117,121 @@ end
 
 No setup, no doubles, no gateways. Fast, isolated, and focused on the rule itself.
 
+## Polymorphic behaviour from the database
+
+Domain objects can go further than holding shared rules. By constructing different domain object types from database data, the gateway can make behaviour vary based on persistent state — without the use case ever needing to know which type it is working with.
+
+Consider customer pricing tiers. A naive use case branches on a tier flag:
+
+```ruby
+class PlaceOrder
+  def execute(customer_id:, items:)
+    customer = @customer_gateway.find(customer_id)
+    pricing = OrderPricing.new(items)
+
+    total = case customer[:tier]
+            when 'wholesale'  then pricing.subtotal * 0.6
+            when 'premium'    then pricing.subtotal * 0.8
+            else                   pricing.subtotal
+            end
+
+    id = @order_gateway.save(customer_id: customer_id, items: items, total: total)
+    { order_id: id }
+  end
+end
+```
+
+Every time a new tier is introduced the use case must change. Adding a `'vip'` tier means finding and updating every use case that prices orders.
+
+### Encode the variation in domain objects
+
+Define a class per tier, each responding to the same interface:
+
+```ruby
+class StandardCustomer
+  def discount_rate
+    1.0
+  end
+end
+
+class PremiumCustomer
+  def discount_rate
+    0.8
+  end
+end
+
+class WholesaleCustomer
+  def discount_rate
+    0.6
+  end
+end
+```
+
+The gateway reads the `tier` column and constructs the right type:
+
+```ruby
+class SequelCustomerGateway
+  TIER_CLASSES = {
+    'standard'  => StandardCustomer,
+    'premium'   => PremiumCustomer,
+    'wholesale' => WholesaleCustomer
+  }.freeze
+
+  def find(id)
+    row = @customers.where(id: id).first
+    tier_class = TIER_CLASSES.fetch(row[:tier], StandardCustomer)
+    tier_class.new
+  end
+end
+```
+
+The use case no longer needs to know what type of customer it has:
+
+```ruby
+class PlaceOrder
+  def execute(customer_id:, items:)
+    customer = @customer_gateway.find(customer_id)
+    total = OrderPricing.new(items).subtotal * customer.discount_rate
+
+    id = @order_gateway.save(customer_id: customer_id, items: items, total: total)
+    { order_id: id }
+  end
+end
+```
+
+Adding a `VipCustomer` with a 50% discount rate requires a new class and one new line in the gateway's mapping. The use case, the `UpdateOrder` use case, and any other use case that prices orders are untouched.
+
+### Testing
+
+Each domain class is trivial to test in isolation:
+
+```ruby
+describe WholesaleCustomer do
+  it 'has a 40% discount rate' do
+    expect(described_class.new.discount_rate).to eq(0.6)
+  end
+end
+```
+
+The fake gateway used in acceptance tests can return domain objects by type directly, without a database:
+
+```ruby
+class InMemoryCustomerGateway
+  def find(id)
+    @customers[id]
+  end
+
+  def save(id:, tier:)
+    tier_class = SequelCustomerGateway::TIER_CLASSES.fetch(tier, StandardCustomer)
+    @customers[id] = tier_class.new
+  end
+end
+```
+
+By sharing the `TIER_CLASSES` mapping with the real gateway, the fake stays honest — the same domain object types are exercised in tests and production.
+
 ## The guiding question
 
 Before moving logic into the domain, ask: _must this rule hold for all use cases across the system?_
 
-If the rule is specific to one use case, it belongs in the use case. If it is a constraint on the domain itself — something that would be wrong regardless of which use case triggered it — it belongs in the domain.
+If the rule is specific to one use case, it belongs in the use case. If it is a constraint on the domain itself — something that would be wrong regardless of which use case triggered it — it belongs in the domain. And if the rule varies based on data, encode that variation in domain object types and let the gateway decide which to construct.

--- a/learn/intermediate/extend-with-domain.md
+++ b/learn/intermediate/extend-with-domain.md
@@ -1,0 +1,124 @@
+# Extend Use Case behaviour with Domain objects
+
+When you start building a Clean Architecture system, the advice is to keep your domain objects simple — just data, minimal behaviour. Let the use cases carry the logic. This is deliberate.
+
+As [domain.md](../../domain.md) puts it: _it is cheaper to specialise Use Cases, resulting in an anemic domain model, then evolve the systems towards generalisations once patterns emerge._
+
+This guide is about recognising when those patterns have emerged, and moving logic into the domain.
+
+## Starting point: logic in the use case
+
+Early on, a pricing rule lives in the use case that needs it:
+
+```ruby
+class PlaceOrder
+  def execute(customer_id:, items:)
+    subtotal = items.sum { |item| item[:price] * item[:quantity] }
+    total = items.sum { |i| i[:quantity] } >= 10 ? subtotal * 0.9 : subtotal
+
+    id = @order_gateway.save(customer_id: customer_id, items: items, total: total)
+    { order_id: id }
+  end
+end
+```
+
+This is fine. One use case, one place the rule lives.
+
+## The signal: duplication across use cases
+
+A second use case needs the same rule:
+
+```ruby
+class UpdateOrder
+  def execute(order_id:, items:)
+    subtotal = items.sum { |item| item[:price] * item[:quantity] }
+    total = items.sum { |i| i[:quantity] } >= 10 ? subtotal * 0.9 : subtotal
+
+    @order_gateway.update(order_id: order_id, items: items, total: total)
+    { order_id: order_id }
+  end
+end
+```
+
+The bulk discount rule is now in two places. When the discount threshold changes from 10 to 20, both use cases need updating. Miss one, and the system is inconsistent.
+
+This is the signal: a rule that must be valid for multiple use cases belongs in the domain.
+
+## Moving logic into a domain object
+
+```ruby
+class OrderPricing
+  BULK_THRESHOLD = 10
+  BULK_DISCOUNT  = 0.9
+
+  def initialize(items)
+    @items = items
+  end
+
+  def total
+    bulk? ? subtotal * BULK_DISCOUNT : subtotal
+  end
+
+  private
+
+  def subtotal
+    @items.sum { |item| item[:price] * item[:quantity] }
+  end
+
+  def bulk?
+    @items.sum { |i| i[:quantity] } >= BULK_THRESHOLD
+  end
+end
+```
+
+Both use cases simplify to:
+
+```ruby
+class PlaceOrder
+  def execute(customer_id:, items:)
+    total = OrderPricing.new(items).total
+    id = @order_gateway.save(customer_id: customer_id, items: items, total: total)
+    { order_id: id }
+  end
+end
+
+class UpdateOrder
+  def execute(order_id:, items:)
+    total = OrderPricing.new(items).total
+    @order_gateway.update(order_id: order_id, items: items, total: total)
+    { order_id: order_id }
+  end
+end
+```
+
+The rule has one home. Use cases become orchestrators — they coordinate the flow, but the knowledge belongs to the domain.
+
+## Testing the domain object independently
+
+Domain objects have no gateways and no use case dependencies. They are the easiest things in your system to test:
+
+```ruby
+describe OrderPricing do
+  context 'with fewer than 10 items' do
+    it 'returns the full subtotal' do
+      items = [{ price: 10, quantity: 9 }]
+      expect(OrderPricing.new(items).total).to eq(90)
+    end
+  end
+
+  context 'with 10 or more items' do
+    it 'applies the bulk discount' do
+      items = [{ price: 10, quantity: 10 }]
+      expect(OrderPricing.new(items).total).to eq(90)
+    end
+  end
+end
+```
+
+No setup, no doubles, no gateways. Fast, isolated, and focused on the rule itself.
+
+## The guiding question
+
+Before moving logic into the domain, ask: _must this rule hold for all use cases across the system?_
+
+If the rule is specific to one use case, it belongs in the use case. If it is a constraint on the domain itself — something that would be wrong regardless of which use case triggered it — it belongs in the domain.

--- a/learn/intermediate/extract-use-case-from-another.md
+++ b/learn/intermediate/extract-use-case-from-another.md
@@ -83,13 +83,30 @@ class PlaceOrder
 end
 ```
 
+## When extraction makes sense
+
+Extraction is worthwhile when:
+
+- **The extracted use case needs to be called directly** by a delivery mechanism or API in its own right. If `ReserveInventory` can also be triggered by a warehouse management interface, it earns its own existence as a first-class use case.
+- **The code is genuinely too complicated** to reason about or test as one unit. Four dependencies and fifty lines is a signal worth acting on.
+
+## The downsides
+
+Extraction is not a panacea. It comes with real costs:
+
+**Sharing information between use cases becomes harder.** When logic lives in one use case, intermediate values computed early can be used later. Once you split across use cases, each invocation starts fresh. You end up passing more data through the interface, or reading data a second time that you have already read.
+
+**More database calls.** Domain objects cannot be shared across use case boundaries without breaking the architectural philosophy — a domain object that escapes a use case is a leaked internal (see [Don't leak your internals](../basics/do-not-leak-your-internals.md)). This means each extracted use case may reload data the orchestrating use case already has. In the example above, if `NotifyOrderPlaced` needs order details that `PlaceOrder` already computed, it must fetch them again.
+
+Apply extraction when the benefits — reusability, testability, separation of concerns — outweigh these costs. Not every large use case needs to be split.
+
 ## Testing each piece independently
 
-Each use case can now be tested with stub collaborators rather than a full wiring:
+Each use case can be tested with stub collaborators rather than a full wiring:
 
 ```ruby
 describe PlaceOrder do
-  let(:order_gateway)      { instance_double(InMemoryOrderGateway, save: 42) }
+  let(:order_gateway)       { instance_double(InMemoryOrderGateway, save: 42) }
   let(:notify_order_placed) { double(:notify_order_placed, execute: {}) }
   let(:reserve_inventory)   { double(:reserve_inventory, execute: {}) }
 
@@ -117,27 +134,88 @@ end
 
 ## Wiring it together
 
-In your [dependency factory](./keep-your-wiring-DRY.md), compose the use cases:
+In your [dependency factory](./keep-your-wiring-DRY.md), compose the use cases. Use a lookup hash rather than a case statement — adding a new use case means adding an entry, not modifying a branch:
 
 ```ruby
+def use_cases
+  {
+    place_order: -> {
+      PlaceOrder.new(
+        order_gateway: order_gateway,
+        notify_order_placed: get_use_case(:notify_order_placed),
+        reserve_inventory: get_use_case(:reserve_inventory)
+      )
+    },
+    notify_order_placed: -> {
+      NotifyOrderPlaced.new(customer_gateway: customer_gateway, mailer: mailer)
+    },
+    reserve_inventory: -> {
+      ReserveInventory.new(inventory_gateway: inventory_gateway)
+    }
+  }
+end
+
 def get_use_case(name)
-  case name
-  when :place_order
-    PlaceOrder.new(
-      order_gateway: order_gateway,
-      notify_order_placed: get_use_case(:notify_order_placed),
-      reserve_inventory: get_use_case(:reserve_inventory)
-    )
-  when :notify_order_placed
-    NotifyOrderPlaced.new(customer_gateway: customer_gateway, mailer: mailer)
-  when :reserve_inventory
-    ReserveInventory.new(inventory_gateway: inventory_gateway)
+  use_cases.fetch(name).call
+end
+```
+
+Each use case remains individually accessible — `notify_order_placed` can be triggered by other use cases or delivery mechanisms without duplication.
+
+## An alternative: the event publisher
+
+Direct injection of collaborator use cases means `PlaceOrder` must know the names of every downstream use case it triggers. Adding `UpdateLoyaltyPoints` as a new consequence of placing an order means changing `PlaceOrder`.
+
+An event publisher inverts this. `PlaceOrder` publishes a signal; downstream use cases subscribe to it. `PlaceOrder` no longer knows what cares about its outcome.
+
+```ruby
+class PlaceOrder
+  def initialize(order_gateway:, event_publisher:)
+    @order_gateway = order_gateway
+    @event_publisher = event_publisher
+  end
+
+  def execute(customer_id:, items:)
+    order_id = @order_gateway.save(customer_id: customer_id, items: items)
+    @event_publisher.publish(:order_placed, customer_id: customer_id, order_id: order_id, items: items)
+    { order_id: order_id }
   end
 end
 ```
 
-Each use case remains individually accessible — `notify_order_placed` can be triggered by other use cases in the future without duplication.
+The publisher calls each subscriber in turn, synchronously:
+
+```ruby
+class EventPublisher
+  def initialize
+    @subscribers = Hash.new { |h, k| h[k] = [] }
+  end
+
+  def subscribe(event, use_case)
+    @subscribers[event] << use_case
+    self
+  end
+
+  def publish(event, payload)
+    @subscribers[event].each { |use_case| use_case.execute(**payload) }
+  end
+end
+```
+
+Subscriptions are wired up in the [dependency factory](./keep-your-wiring-DRY.md):
+
+```ruby
+def event_publisher
+  @event_publisher ||= EventPublisher.new
+    .subscribe(:order_placed, get_use_case(:notify_order_placed))
+    .subscribe(:order_placed, get_use_case(:reserve_inventory))
+end
+```
+
+Adding `UpdateLoyaltyPoints` as a new subscriber requires one new line in the factory. `PlaceOrder` is untouched.
+
+The same downsides around database calls and information sharing apply — each subscriber starts fresh and may re-read data. But the coupling between `PlaceOrder` and its downstream consequences is eliminated entirely.
 
 ## From the trenches
 
-Extracted use cases are also easier to replace. If notification sending moves to a background queue, only `NotifyOrderPlaced` changes. `PlaceOrder` and its tests are untouched — as long as the new implementation still responds to `execute`.
+Extracted use cases are easier to replace. If notification sending moves to a background queue, only `NotifyOrderPlaced` changes — as long as the new implementation still responds to `execute`. With an event publisher, that swap happens in the factory without touching any use case at all.

--- a/learn/intermediate/extract-use-case-from-another.md
+++ b/learn/intermediate/extract-use-case-from-another.md
@@ -1,0 +1,143 @@
+# Extracting a Use Case from a Use Case
+
+A use case should do one thing. As systems grow, what started as one thing often quietly becomes two or three. The tell is length — and the feeling that testing this use case requires setting up far too much.
+
+## The smell
+
+```ruby
+class PlaceOrder
+  def initialize(order_gateway:, customer_gateway:, mailer:, inventory_gateway:)
+    @order_gateway = order_gateway
+    @customer_gateway = customer_gateway
+    @mailer = mailer
+    @inventory_gateway = inventory_gateway
+  end
+
+  def execute(customer_id:, items:)
+    order_id = @order_gateway.save(customer_id: customer_id, items: items)
+
+    customer = @customer_gateway.find(customer_id)
+    @mailer.send_confirmation(to: customer[:email], order_id: order_id)
+
+    items.each do |item|
+      @inventory_gateway.decrement(sku: item[:sku], quantity: item[:quantity])
+    end
+
+    { order_id: order_id }
+  end
+end
+```
+
+`PlaceOrder` has four dependencies and is doing three distinct things: saving the order, sending a confirmation, and updating inventory. To test it in isolation you must arrange four collaborators. A change to how notifications are sent requires touching an order use case.
+
+## Extracting collaborator use cases
+
+Pull each concern into its own use case:
+
+```ruby
+class NotifyOrderPlaced
+  def initialize(customer_gateway:, mailer:)
+    @customer_gateway = customer_gateway
+    @mailer = mailer
+  end
+
+  def execute(customer_id:, order_id:)
+    customer = @customer_gateway.find(customer_id)
+    @mailer.send_confirmation(to: customer[:email], order_id: order_id)
+    {}
+  end
+end
+```
+
+```ruby
+class ReserveInventory
+  def initialize(inventory_gateway:)
+    @inventory_gateway = inventory_gateway
+  end
+
+  def execute(items:)
+    items.each do |item|
+      @inventory_gateway.decrement(sku: item[:sku], quantity: item[:quantity])
+    end
+    {}
+  end
+end
+```
+
+`PlaceOrder` becomes an orchestrator, with the extracted use cases injected as collaborators — exactly like gateways:
+
+```ruby
+class PlaceOrder
+  def initialize(order_gateway:, notify_order_placed:, reserve_inventory:)
+    @order_gateway = order_gateway
+    @notify_order_placed = notify_order_placed
+    @reserve_inventory = reserve_inventory
+  end
+
+  def execute(customer_id:, items:)
+    order_id = @order_gateway.save(customer_id: customer_id, items: items)
+    @notify_order_placed.execute(customer_id: customer_id, order_id: order_id)
+    @reserve_inventory.execute(items: items)
+    { order_id: order_id }
+  end
+end
+```
+
+## Testing each piece independently
+
+Each use case can now be tested with stub collaborators rather than a full wiring:
+
+```ruby
+describe PlaceOrder do
+  let(:order_gateway)      { instance_double(InMemoryOrderGateway, save: 42) }
+  let(:notify_order_placed) { double(:notify_order_placed, execute: {}) }
+  let(:reserve_inventory)   { double(:reserve_inventory, execute: {}) }
+
+  subject do
+    PlaceOrder.new(
+      order_gateway: order_gateway,
+      notify_order_placed: notify_order_placed,
+      reserve_inventory: reserve_inventory
+    )
+  end
+
+  it 'returns the order id' do
+    result = subject.execute(customer_id: 1, items: [])
+    expect(result[:order_id]).to eq(42)
+  end
+
+  it 'notifies that the order was placed' do
+    subject.execute(customer_id: 1, items: [])
+    expect(notify_order_placed).to have_received(:execute).with(customer_id: 1, order_id: 42)
+  end
+end
+```
+
+`NotifyOrderPlaced` and `ReserveInventory` each get their own focused test with only the collaborators they actually need.
+
+## Wiring it together
+
+In your [dependency factory](./keep-your-wiring-DRY.md), compose the use cases:
+
+```ruby
+def get_use_case(name)
+  case name
+  when :place_order
+    PlaceOrder.new(
+      order_gateway: order_gateway,
+      notify_order_placed: get_use_case(:notify_order_placed),
+      reserve_inventory: get_use_case(:reserve_inventory)
+    )
+  when :notify_order_placed
+    NotifyOrderPlaced.new(customer_gateway: customer_gateway, mailer: mailer)
+  when :reserve_inventory
+    ReserveInventory.new(inventory_gateway: inventory_gateway)
+  end
+end
+```
+
+Each use case remains individually accessible — `notify_order_placed` can be triggered by other use cases in the future without duplication.
+
+## From the trenches
+
+Extracted use cases are also easier to replace. If notification sending moves to a background queue, only `NotifyOrderPlaced` changes. `PlaceOrder` and its tests are untouched — as long as the new implementation still responds to `execute`.

--- a/learn/intermediate/flexible-presenters.md
+++ b/learn/intermediate/flexible-presenters.md
@@ -1,0 +1,133 @@
+# Presenters are more flexible
+
+Returning a hash from a use case is the right default. It is simple, easy to test, and works well for most situations.
+
+But as a system grows you will encounter use cases that need to communicate differently to different callers — a JSON API and an HTML view handling success and failure in completely different ways. This is where returning a hash starts to show its limits.
+
+## The hash approach and its friction
+
+```ruby
+class TurnLightOn
+  def execute(light_id:)
+    light = @light_gateway.find(light_id)
+    return { success: false, errors: [:light_not_found] } if light.nil?
+    light.turn_on
+    { success: true }
+  end
+end
+```
+
+The caller must inspect the result and branch on it:
+
+```ruby
+# In a controller
+result = turn_light_on.execute(light_id: id)
+if result[:success]
+  redirect_to lights_path
+else
+  render :edit, status: :unprocessable_entity
+end
+```
+
+The controller is now coupled to the shape of the hash. Every caller that handles failure must know that `errors: [:light_not_found]` is how this use case communicates that outcome.
+
+## The presenter pattern
+
+Instead of returning a hash, the use case accepts a presenter object and calls methods on it:
+
+```ruby
+class TurnLightOn
+  def initialize(light_gateway:)
+    @light_gateway = light_gateway
+  end
+
+  def execute(light_id:, presenter:)
+    light = @light_gateway.find(light_id)
+    return presenter.light_not_found if light.nil?
+    light.turn_on
+    presenter.success
+  end
+end
+```
+
+The use case defines the outcomes — `success` and `light_not_found` — but delegates the response entirely to the presenter. The caller provides its own implementation:
+
+```ruby
+# HTML controller presenter
+class TurnLightOnPresenter
+  attr_reader :redirect, :render
+
+  def success
+    @redirect = :lights_path
+  end
+
+  def light_not_found
+    @render = { template: :edit, status: :unprocessable_entity }
+  end
+end
+
+presenter = TurnLightOnPresenter.new
+turn_light_on.execute(light_id: id, presenter: presenter)
+redirect_to presenter.redirect if presenter.redirect
+render presenter.render[:template], status: presenter.render[:status] if presenter.render
+```
+
+A JSON API caller provides a different implementation:
+
+```ruby
+class TurnLightOnJsonPresenter
+  attr_reader :body, :status
+
+  def success
+    @status = 200
+    @body = { ok: true }.to_json
+  end
+
+  def light_not_found
+    @status = 404
+    @body = { errors: ['light_not_found'] }.to_json
+  end
+end
+```
+
+The use case is unchanged. Both callers get exactly the interface they need.
+
+## Testing with the presenter
+
+In tests, a simple struct captures which outcome was called:
+
+```ruby
+describe TurnLightOn do
+  let(:presenter) { double(:presenter) }
+  let(:light_gateway) { instance_double(InMemoryLightGateway) }
+  let(:use_case) { described_class.new(light_gateway: light_gateway) }
+
+  context 'when the light exists' do
+    before { allow(light_gateway).to receive(:find).and_return({ id: 1, on: false }) }
+
+    it 'calls success on the presenter' do
+      expect(presenter).to receive(:success)
+      use_case.execute(light_id: 1, presenter: presenter)
+    end
+  end
+
+  context 'when the light does not exist' do
+    before { allow(light_gateway).to receive(:find).and_return(nil) }
+
+    it 'calls light_not_found on the presenter' do
+      expect(presenter).to receive(:light_not_found)
+      use_case.execute(light_id: 1, presenter: presenter)
+    end
+  end
+end
+```
+
+## When to use a presenter
+
+The hash return is simpler — prefer it unless you have a concrete reason to reach for a presenter. Good reasons include:
+
+- Multiple callers that handle outcomes fundamentally differently
+- The use case has several distinct outcome paths that the caller must all handle explicitly
+- You want the compiler (in typed languages) to enforce that callers handle every outcome
+
+A use case that returns `{ success: true }` or `{ success: false, errors: [...] }` does not need a presenter. A use case that has four distinct outcomes — success, not found, not authorised, validation failure — probably does.

--- a/learn/intermediate/flexible-presenters.md
+++ b/learn/intermediate/flexible-presenters.md
@@ -213,9 +213,54 @@ end
 
 No branching in the gateway. Adding a new state means a new domain class and one new entry in `CONSTRUCTORS`.
 
-### The use case
+### The use case: two approaches
 
-The use case is responsible for mapping domain object types to presenter calls. A lookup hash keyed on the domain class replaces any branching — and keeps presenter awareness out of the domain entirely:
+There are two ways to dispatch from domain object to presenter. Each makes a different trade-off.
+
+#### Option A: delegate to the domain object
+
+Each domain object implements a `present_to` method that calls the appropriate presenter method with its own data:
+
+```ruby
+class PendingOrder
+  # ...
+  def present_to(presenter)
+    presenter.pending(id: @id, items: @items)
+  end
+end
+
+class ConfirmedOrder
+  # ...
+  def present_to(presenter)
+    presenter.confirmed(id: @id, items: @items, confirmed_at: @confirmed_at)
+  end
+end
+
+class DispatchedOrder
+  # ...
+  def present_to(presenter)
+    presenter.dispatched(id: @id, items: @items, tracking_number: @tracking_number)
+  end
+end
+```
+
+The use case simply delegates:
+
+```ruby
+def execute(order_id:, presenter:)
+  order = @order_gateway.find_by_id(order_id)
+  return presenter.not_found unless order
+  order.present_to(presenter)
+end
+```
+
+**Pros:** Truly open/closed — adding a new state requires only a new class that implements `present_to`. The use case never changes. The dispatch is fully polymorphic with no lookup table to maintain.
+
+**Cons:** The domain object becomes aware of a use-case-specific presenter interface. If `PendingOrder` is used across multiple use cases with different presenter interfaces, it must either implement multiple `present_to_*` methods or pick one to favour. Presenter method names leak into the domain's vocabulary.
+
+#### Option B: lookup hash in the use case
+
+The domain objects remain pure data. The use case owns a `PRESENT` dispatch table keyed on the domain class:
 
 ```ruby
 class ViewOrder
@@ -237,7 +282,9 @@ class ViewOrder
 end
 ```
 
-No branching. The `PRESENT` table is the only place that knows about the three states. If a fourth state is added, one new entry is added to `PRESENT` — the `execute` method is untouched.
+**Pros:** Domain objects are free of any presenter knowledge — they are pure domain concepts. Each use case defines its own dispatch table independently, so the same domain objects can be used in contexts with entirely different presenter interfaces.
+
+**Cons:** The use case must be updated when a new domain class is added — it is not fully open/closed. Keying on `order.class` is also fragile: renaming a class silently breaks the lookup, and subclasses will not be found unless explicitly added. The use case implicitly knows about every concrete type in the hierarchy.
 
 ### The delivery mechanism
 

--- a/learn/intermediate/flexible-presenters.md
+++ b/learn/intermediate/flexible-presenters.md
@@ -286,6 +286,81 @@ end
 
 **Cons:** The use case must be updated when a new domain class is added — it is not fully open/closed. Keying on `order.class` is also fragile: renaming a class silently breaks the lookup, and subclasses will not be found unless explicitly added. The use case implicitly knows about every concrete type in the hierarchy.
 
+#### Option C: strategy objects injected at build time
+
+A strategy object per domain type is responsible for calling the right presenter methods. The builder injects the appropriate strategy into each domain object at construction time. The domain object delegates `present_to` to its strategy — knowing it has one, but not what it does:
+
+```ruby
+class PendingOrderPresentationStrategy
+  def present(order, presenter)
+    presenter.pending(id: order.id, items: order.items)
+  end
+end
+
+class ConfirmedOrderPresentationStrategy
+  def present(order, presenter)
+    presenter.confirmed(id: order.id, items: order.items, confirmed_at: order.confirmed_at)
+  end
+end
+
+class DispatchedOrderPresentationStrategy
+  def present(order, presenter)
+    presenter.dispatched(id: order.id, items: order.items, tracking_number: order.tracking_number)
+  end
+end
+```
+
+The domain objects hold a reference to the injected strategy:
+
+```ruby
+class PendingOrder
+  attr_reader :id, :items
+
+  def initialize(id:, items:, presentation_strategy:)
+    @id = id
+    @items = items
+    @presentation_strategy = presentation_strategy
+  end
+
+  def present_to(presenter)
+    @presentation_strategy.present(self, presenter)
+  end
+end
+```
+
+The builder wires the right strategy into each constructor lambda:
+
+```ruby
+class OrderBuilder
+  CONSTRUCTORS = {
+    'pending'    => ->(row) { PendingOrder.new(id: row[:id], items: row[:items], presentation_strategy: PendingOrderPresentationStrategy.new) },
+    'confirmed'  => ->(row) { ConfirmedOrder.new(id: row[:id], items: row[:items], confirmed_at: row[:confirmed_at], presentation_strategy: ConfirmedOrderPresentationStrategy.new) },
+    'dispatched' => ->(row) { DispatchedOrder.new(id: row[:id], items: row[:items], tracking_number: row[:tracking_number], presentation_strategy: DispatchedOrderPresentationStrategy.new) }
+  }.freeze
+
+  def self.build(row)
+    constructor = CONSTRUCTORS.fetch(row[:status], CONSTRUCTORS['pending'])
+    constructor.call(row)
+  end
+end
+```
+
+The use case is identical to Option A — it just calls `present_to`:
+
+```ruby
+def execute(order_id:, presenter:)
+  order = @order_gateway.find_by_id(order_id)
+  return presenter.not_found unless order
+  order.present_to(presenter)
+end
+```
+
+**Pros:** The use case is open/closed — it never changes when new types are added. Domain objects do not know about specific presenter interfaces, only that they hold a strategy. Different use cases can inject different strategies for the same domain type, giving full flexibility without coupling. No fragile `.class` lookup.
+
+**Cons:** More moving parts — a strategy class per type, strategy injection in the builder, and a `present_to` delegation method on every domain object. The indirection can be harder to follow.
+
+**When it is worth the complexity:** Strategy injection earns its place when the aggregate root domain objects are complex hierarchies — for example, an `Order` composed of `LineItem` objects that are themselves polymorphic (`PhysicalItem`, `DigitalItem`, `SubscriptionItem`), each with their own display nuances. A strategy can traverse and present this whole object graph with full knowledge of the hierarchy, while the domain objects and the use case remain oblivious to the presentation logic entirely. For simple flat domain objects, Options A or B are sufficient.
+
 ### The delivery mechanism
 
 The controller self-shunts as the presenter. Each outcome is a named method — the `show` action itself contains no conditionals:

--- a/learn/intermediate/flexible-presenters.md
+++ b/learn/intermediate/flexible-presenters.md
@@ -2,121 +2,219 @@
 
 Returning a hash from a use case is the right default. It is simple, easy to test, and works well for most situations.
 
-But as a system grows you will encounter use cases that need to communicate differently to different callers — a JSON API and an HTML view handling success and failure in completely different ways. This is where returning a hash starts to show its limits.
+But as a system grows, use cases accumulate more outcomes. Each new outcome requires every caller to branch on the result hash. Left unchecked, the same `if` statement ends up duplicated across the codebase — and this is a symptom of zero polymorphism.
 
-## The hash approach and its friction
+## The zero polymorphism problem
+
+Consider a use case that can fail in multiple ways:
 
 ```ruby
-class TurnLightOn
-  def execute(light_id:)
-    light = @light_gateway.find(light_id)
-    return { success: false, errors: [:light_not_found] } if light.nil?
-    light.turn_on
-    { success: true }
+class PlaceOrder
+  def execute(customer_id:, items:)
+    customer = @customer_gateway.find(customer_id)
+    return { status: :customer_not_found } unless customer
+    return { status: :no_items } if items.empty?
+    return { status: :out_of_stock } unless @inventory_gateway.all_available?(items)
+
+    order_id = @order_gateway.save(customer_id: customer_id, items: items)
+    { status: :success, order_id: order_id }
   end
 end
 ```
 
-The caller must inspect the result and branch on it:
+Every caller must now branch on `status`:
 
 ```ruby
-# In a controller
-result = turn_light_on.execute(light_id: id)
-if result[:success]
-  redirect_to lights_path
-else
-  render :edit, status: :unprocessable_entity
+# HTML controller
+result = place_order.execute(customer_id: id, items: params[:items])
+case result[:status]
+when :success        then redirect_to order_path(result[:order_id])
+when :customer_not_found then redirect_to login_path
+when :no_items       then render :cart, alert: 'Your cart is empty'
+when :out_of_stock   then render :cart, alert: 'Some items are out of stock'
 end
 ```
 
-The controller is now coupled to the shape of the hash. Every caller that handles failure must know that `errors: [:light_not_found]` is how this use case communicates that outcome.
+```ruby
+# JSON API controller
+result = place_order.execute(customer_id: id, items: params[:items])
+case result[:status]
+when :success        then json({ order_id: result[:order_id] }, status: 201)
+when :customer_not_found then json({ error: 'not_found' }, status: 404)
+when :no_items       then json({ error: 'no_items' }, status: 422)
+when :out_of_stock   then json({ error: 'out_of_stock' }, status: 422)
+end
+```
+
+The same four-way branch appears in every delivery mechanism. Add a fifth outcome to the use case and every caller must be updated. This is the definition of zero polymorphism: variation handled by repeated conditionals rather than by different objects.
+
+In the worst case the same `if` appears in all three layers — the gateway inspecting a type to build the right data structure, the use case inspecting it again to apply the right rule, the delivery mechanism inspecting it a third time to render the right response. The [extend-with-domain](./extend-with-domain.md) guide covers eliminating the gateway and use case branches through polymorphic domain objects. The presenter pattern eliminates the delivery mechanism branch.
 
 ## The presenter pattern
 
-Instead of returning a hash, the use case accepts a presenter object and calls methods on it:
+Instead of returning a hash, the use case accepts a presenter and calls a named method per outcome:
 
 ```ruby
-class TurnLightOn
-  def initialize(light_gateway:)
-    @light_gateway = light_gateway
+class PlaceOrder
+  def initialize(order_gateway:, customer_gateway:, inventory_gateway:)
+    @order_gateway = order_gateway
+    @customer_gateway = customer_gateway
+    @inventory_gateway = inventory_gateway
   end
 
-  def execute(light_id:, presenter:)
-    light = @light_gateway.find(light_id)
-    return presenter.light_not_found if light.nil?
-    light.turn_on
-    presenter.success
+  def execute(customer_id:, items:, presenter:)
+    customer = @customer_gateway.find(customer_id)
+    return presenter.customer_not_found unless customer
+    return presenter.no_items if items.empty?
+    return presenter.out_of_stock unless @inventory_gateway.all_available?(items)
+
+    order_id = @order_gateway.save(customer_id: customer_id, items: items)
+    presenter.success(order_id: order_id)
   end
 end
 ```
 
-The use case defines the outcomes — `success` and `light_not_found` — but delegates the response entirely to the presenter. The caller provides its own implementation:
+Each caller provides its own implementation of the outcome methods. The branching disappears — replaced by polymorphism.
+
+## Self-shunting: the controller as the presenter
+
+The simplest way to provide a presenter is to make the controller the presenter itself. The controller passes `self` to the use case and implements the outcome methods directly:
 
 ```ruby
-# HTML controller presenter
-class TurnLightOnPresenter
-  attr_reader :redirect, :render
-
-  def success
-    @redirect = :lights_path
+class OrdersController < ApplicationController
+  def create
+    place_order.execute(
+      customer_id: current_user.id,
+      items: params[:items],
+      presenter: self
+    )
   end
 
-  def light_not_found
-    @render = { template: :edit, status: :unprocessable_entity }
-  end
-end
-
-presenter = TurnLightOnPresenter.new
-turn_light_on.execute(light_id: id, presenter: presenter)
-redirect_to presenter.redirect if presenter.redirect
-render presenter.render[:template], status: presenter.render[:status] if presenter.render
-```
-
-A JSON API caller provides a different implementation:
-
-```ruby
-class TurnLightOnJsonPresenter
-  attr_reader :body, :status
-
-  def success
-    @status = 200
-    @body = { ok: true }.to_json
+  def success(order_id:)
+    redirect_to order_path(order_id)
   end
 
-  def light_not_found
-    @status = 404
-    @body = { errors: ['light_not_found'] }.to_json
+  def customer_not_found
+    redirect_to login_path
+  end
+
+  def no_items
+    render :cart, alert: 'Your cart is empty'
+  end
+
+  def out_of_stock
+    render :cart, alert: 'Some items are out of stock'
   end
 end
 ```
 
-The use case is unchanged. Both callers get exactly the interface they need.
+This is called self-shunting. There is no indirection — the controller is the presenter. Each outcome is a named method, not a branch in `create`. Adding a new outcome means adding a new method, not modifying an existing one.
+
+The JSON API controller handles the same outcomes differently, with no shared code needed:
+
+```ruby
+class Api::OrdersController < ApplicationController
+  def create
+    place_order.execute(
+      customer_id: current_user.id,
+      items: params[:items],
+      presenter: self
+    )
+  end
+
+  def success(order_id:)
+    render json: { order_id: order_id }, status: :created
+  end
+
+  def customer_not_found
+    render json: { error: 'customer_not_found' }, status: :not_found
+  end
+
+  def no_items
+    render json: { error: 'no_items' }, status: :unprocessable_entity
+  end
+
+  def out_of_stock
+    render json: { error: 'out_of_stock' }, status: :unprocessable_entity
+  end
+end
+```
+
+## Separate presenter objects
+
+When the presentation logic itself is complex or needs to be shared across controllers, extract it into a dedicated presenter object rather than shunting into the controller:
+
+```ruby
+class PlaceOrderPresenter
+  attr_reader :redirect_to, :render_template, :alert
+
+  def success(order_id:)
+    @redirect_to = "/orders/#{order_id}"
+  end
+
+  def customer_not_found
+    @redirect_to = '/login'
+  end
+
+  def no_items
+    @render_template = :cart
+    @alert = 'Your cart is empty'
+  end
+
+  def out_of_stock
+    @render_template = :cart
+    @alert = 'Some items are out of stock'
+  end
+end
+```
+
+The controller instantiates and interrogates the presenter:
+
+```ruby
+def create
+  presenter = PlaceOrderPresenter.new
+  place_order.execute(customer_id: current_user.id, items: params[:items], presenter: presenter)
+  redirect_to presenter.redirect_to and return if presenter.redirect_to
+  render presenter.render_template, alert: presenter.alert
+end
+```
 
 ## Testing with the presenter
 
-In tests, a simple struct captures which outcome was called:
+In tests, use a double to assert which outcome was called:
 
 ```ruby
-describe TurnLightOn do
-  let(:presenter) { double(:presenter) }
-  let(:light_gateway) { instance_double(InMemoryLightGateway) }
-  let(:use_case) { described_class.new(light_gateway: light_gateway) }
+describe PlaceOrder do
+  let(:presenter)          { double(:presenter) }
+  let(:order_gateway)      { InMemoryOrderGateway.new }
+  let(:customer_gateway)   { InMemoryCustomerGateway.new }
+  let(:inventory_gateway)  { InMemoryInventoryGateway.new }
 
-  context 'when the light exists' do
-    before { allow(light_gateway).to receive(:find).and_return({ id: 1, on: false }) }
+  subject do
+    described_class.new(
+      order_gateway: order_gateway,
+      customer_gateway: customer_gateway,
+      inventory_gateway: inventory_gateway
+    )
+  end
 
-    it 'calls success on the presenter' do
-      expect(presenter).to receive(:success)
-      use_case.execute(light_id: 1, presenter: presenter)
+  context 'when items are available' do
+    before { customer_gateway.save(id: 1) }
+    before { inventory_gateway.mark_available('SKU-1') }
+
+    it 'calls success with the order id' do
+      expect(presenter).to receive(:success).with(order_id: anything)
+      subject.execute(customer_id: 1, items: [{ sku: 'SKU-1' }], presenter: presenter)
     end
   end
 
-  context 'when the light does not exist' do
-    before { allow(light_gateway).to receive(:find).and_return(nil) }
+  context 'when items are out of stock' do
+    before { customer_gateway.save(id: 1) }
+    before { inventory_gateway.mark_unavailable('SKU-1') }
 
-    it 'calls light_not_found on the presenter' do
-      expect(presenter).to receive(:light_not_found)
-      use_case.execute(light_id: 1, presenter: presenter)
+    it 'calls out_of_stock' do
+      expect(presenter).to receive(:out_of_stock)
+      subject.execute(customer_id: 1, items: [{ sku: 'SKU-1' }], presenter: presenter)
     end
   end
 end
@@ -126,8 +224,8 @@ end
 
 The hash return is simpler — prefer it unless you have a concrete reason to reach for a presenter. Good reasons include:
 
-- Multiple callers that handle outcomes fundamentally differently
-- The use case has several distinct outcome paths that the caller must all handle explicitly
+- The use case has several distinct outcome paths and the same branching is appearing in multiple callers
+- Multiple callers handle outcomes in fundamentally different ways
 - You want the compiler (in typed languages) to enforce that callers handle every outcome
 
-A use case that returns `{ success: true }` or `{ success: false, errors: [...] }` does not need a presenter. A use case that has four distinct outcomes — success, not found, not authorised, validation failure — probably does.
+A use case that returns `{ success: true }` or `{ success: false, errors: [...] }` does not need a presenter. A use case with four distinct outcomes handled differently across two delivery mechanisms probably does.

--- a/learn/intermediate/flexible-presenters.md
+++ b/learn/intermediate/flexible-presenters.md
@@ -140,6 +140,135 @@ class Api::OrdersController < ApplicationController
 end
 ```
 
+## A worked example: polymorphism at every layer
+
+The sections above address the delivery mechanism layer in isolation. This example shows the full chain: the same polymorphism that eliminates branching in the gateway and use case (covered in [extend-with-domain](./extend-with-domain.md)) extends through to the delivery mechanism.
+
+The scenario: viewing an order that can be in one of three states — pending, confirmed, or dispatched. Each state carries different data and should render differently.
+
+### The domain objects
+
+Each state is a separate class. Each knows how to render itself to a presenter by calling the appropriate method — there is no branching, just a direct call:
+
+```ruby
+class PendingOrder
+  def initialize(id:, items:)
+    @id = id
+    @items = items
+  end
+
+  def render_to(presenter)
+    presenter.pending(id: @id, items: @items)
+  end
+end
+
+class ConfirmedOrder
+  def initialize(id:, items:, confirmed_at:)
+    @id = id
+    @items = items
+    @confirmed_at = confirmed_at
+  end
+
+  def render_to(presenter)
+    presenter.confirmed(id: @id, items: @items, confirmed_at: @confirmed_at)
+  end
+end
+
+class DispatchedOrder
+  def initialize(id:, items:, tracking_number:)
+    @id = id
+    @items = items
+    @tracking_number = tracking_number
+  end
+
+  def render_to(presenter)
+    presenter.dispatched(id: @id, items: @items, tracking_number: @tracking_number)
+  end
+end
+```
+
+Notice that each type passes only the data relevant to it. `DispatchedOrder` provides a `tracking_number`; `PendingOrder` does not need one and does not mention it. The presenter method signature for each outcome reflects exactly what that state can offer.
+
+### The gateway and builder
+
+The gateway reads the `status` column and delegates construction to a builder (see [extend-with-domain](./extend-with-domain.md) for the full rationale). Constructor lambdas handle the differing parameters each type requires:
+
+```ruby
+class OrderBuilder
+  CONSTRUCTORS = {
+    'pending'    => ->(row) { PendingOrder.new(id: row[:id], items: row[:items]) },
+    'confirmed'  => ->(row) { ConfirmedOrder.new(id: row[:id], items: row[:items], confirmed_at: row[:confirmed_at]) },
+    'dispatched' => ->(row) { DispatchedOrder.new(id: row[:id], items: row[:items], tracking_number: row[:tracking_number]) }
+  }.freeze
+
+  def self.build(row)
+    constructor = CONSTRUCTORS.fetch(row[:status], CONSTRUCTORS['pending'])
+    constructor.call(row)
+  end
+end
+
+class SequelOrderGateway
+  def find_by_id(id)
+    row = @orders.where(id: id).first
+    return nil unless row
+    items = @line_items.where(order_id: id).all
+    OrderBuilder.build(row.merge(items: items))
+  end
+end
+```
+
+No branching in the gateway. Adding a new state means a new domain class and one new entry in `CONSTRUCTORS`.
+
+### The use case
+
+The use case has no knowledge of order states. It loads the domain object and asks it to render itself:
+
+```ruby
+class ViewOrder
+  def initialize(order_gateway:)
+    @order_gateway = order_gateway
+  end
+
+  def execute(order_id:, presenter:)
+    order = @order_gateway.find_by_id(order_id)
+    return presenter.not_found unless order
+    order.render_to(presenter)
+  end
+end
+```
+
+No branching. The use case is completely insulated from the fact that three order states exist.
+
+### The delivery mechanism
+
+The controller self-shunts as the presenter. Each outcome is a named method — the `show` action itself contains no conditionals:
+
+```ruby
+class OrdersController < ApplicationController
+  def show
+    view_order.execute(order_id: params[:id].to_i, presenter: self)
+  end
+
+  def pending(id:, items:)
+    render :pending, locals: { id: id, items: items }
+  end
+
+  def confirmed(id:, items:, confirmed_at:)
+    render :confirmed, locals: { id: id, items: items, confirmed_at: confirmed_at }
+  end
+
+  def dispatched(id:, items:, tracking_number:)
+    render :dispatched, locals: { id: id, items: items, tracking_number: tracking_number }
+  end
+
+  def not_found
+    render :not_found, status: :not_found
+  end
+end
+```
+
+Adding a fourth state — say `CancelledOrder` — requires: a new domain class, one line in `OrderBuilder::CONSTRUCTORS`, and one new method on the controller. The gateway, the use case, the `show` action, and all other controller methods are untouched.
+
 ## Separate presenter objects
 
 When the presentation logic itself is complex or needs to be shared across controllers, extract it into a dedicated presenter object rather than shunting into the controller:

--- a/learn/intermediate/flexible-presenters.md
+++ b/learn/intermediate/flexible-presenters.md
@@ -148,46 +148,40 @@ The scenario: viewing an order that can be in one of three states — pending, c
 
 ### The domain objects
 
-Each state is a separate class. Each knows how to render itself to a presenter by calling the appropriate method — there is no branching, just a direct call:
+Each state is a separate class, exposing only the data relevant to that state. Domain objects have no knowledge of presenters — they are pure domain concepts:
 
 ```ruby
 class PendingOrder
+  attr_reader :id, :items
+
   def initialize(id:, items:)
     @id = id
     @items = items
   end
-
-  def render_to(presenter)
-    presenter.pending(id: @id, items: @items)
-  end
 end
 
 class ConfirmedOrder
+  attr_reader :id, :items, :confirmed_at
+
   def initialize(id:, items:, confirmed_at:)
     @id = id
     @items = items
     @confirmed_at = confirmed_at
   end
-
-  def render_to(presenter)
-    presenter.confirmed(id: @id, items: @items, confirmed_at: @confirmed_at)
-  end
 end
 
 class DispatchedOrder
+  attr_reader :id, :items, :tracking_number
+
   def initialize(id:, items:, tracking_number:)
     @id = id
     @items = items
     @tracking_number = tracking_number
   end
-
-  def render_to(presenter)
-    presenter.dispatched(id: @id, items: @items, tracking_number: @tracking_number)
-  end
 end
 ```
 
-Notice that each type passes only the data relevant to it. `DispatchedOrder` provides a `tracking_number`; `PendingOrder` does not need one and does not mention it. The presenter method signature for each outcome reflects exactly what that state can offer.
+`DispatchedOrder` exposes a `tracking_number`; `PendingOrder` does not. Each type surfaces only the data it actually has.
 
 ### The gateway and builder
 
@@ -221,10 +215,16 @@ No branching in the gateway. Adding a new state means a new domain class and one
 
 ### The use case
 
-The use case has no knowledge of order states. It loads the domain object and asks it to render itself:
+The use case is responsible for mapping domain object types to presenter calls. A lookup hash keyed on the domain class replaces any branching — and keeps presenter awareness out of the domain entirely:
 
 ```ruby
 class ViewOrder
+  PRESENT = {
+    PendingOrder    => ->(order, p) { p.pending(id: order.id, items: order.items) },
+    ConfirmedOrder  => ->(order, p) { p.confirmed(id: order.id, items: order.items, confirmed_at: order.confirmed_at) },
+    DispatchedOrder => ->(order, p) { p.dispatched(id: order.id, items: order.items, tracking_number: order.tracking_number) }
+  }.freeze
+
   def initialize(order_gateway:)
     @order_gateway = order_gateway
   end
@@ -232,12 +232,12 @@ class ViewOrder
   def execute(order_id:, presenter:)
     order = @order_gateway.find_by_id(order_id)
     return presenter.not_found unless order
-    order.render_to(presenter)
+    PRESENT.fetch(order.class).call(order, presenter)
   end
 end
 ```
 
-No branching. The use case is completely insulated from the fact that three order states exist.
+No branching. The `PRESENT` table is the only place that knows about the three states. If a fourth state is added, one new entry is added to `PRESENT` — the `execute` method is untouched.
 
 ### The delivery mechanism
 

--- a/learn/intermediate/keep-your-wiring-DRY.md
+++ b/learn/intermediate/keep-your-wiring-DRY.md
@@ -1,0 +1,112 @@
+# Keep your wiring DRY
+
+Once you have a handful of use cases and real gateways, you will notice a pattern: every delivery mechanism constructs the same dependencies over and over.
+
+## The smell
+
+```ruby
+post '/orders' do
+  gateway = SequelOrderGateway.new(DB)
+  notifier = EmailNotifier.new(ENV['SMTP_HOST'])
+  result = PlaceOrder.new(order_gateway: gateway, notifier: notifier).execute(params)
+  json(result)
+end
+
+get '/orders' do
+  gateway = SequelOrderGateway.new(DB)
+  result = ListOrders.new(order_gateway: gateway).execute
+  json(result)
+end
+
+delete '/orders/:id' do
+  gateway = SequelOrderGateway.new(DB)
+  result = CancelOrder.new(order_gateway: gateway).execute(order_id: params[:id].to_i)
+  json(result)
+end
+```
+
+Every route knows about `SequelOrderGateway`, `DB`, `EmailNotifier`, and how to construct them. Change a constructor argument and you touch every route. Add a new dependency to `PlaceOrder` and you have to find every place it is constructed.
+
+This is fragility — and it violates the Dependency Inversion Principle. Delivery mechanisms should not know about gateway implementations.
+
+## A dependency factory
+
+Extract all construction into one place:
+
+```ruby
+class Dependencies
+  def initialize(db:)
+    @db = db
+  end
+
+  def get_use_case(name)
+    case name
+    when :place_order
+      PlaceOrder.new(order_gateway: order_gateway, notifier: notifier)
+    when :list_orders
+      ListOrders.new(order_gateway: order_gateway)
+    when :cancel_order
+      CancelOrder.new(order_gateway: order_gateway)
+    end
+  end
+
+  private
+
+  def order_gateway
+    @order_gateway ||= SequelOrderGateway.new(@db)
+  end
+
+  def notifier
+    @notifier ||= EmailNotifier.new(ENV['SMTP_HOST'])
+  end
+end
+```
+
+Delivery mechanisms become unaware of gateways entirely:
+
+```ruby
+post '/orders' do
+  json(dependencies.get_use_case(:place_order).execute(params))
+end
+
+get '/orders' do
+  json(dependencies.get_use_case(:list_orders).execute)
+end
+
+delete '/orders/:id' do
+  json(dependencies.get_use_case(:cancel_order).execute(order_id: params[:id].to_i))
+end
+```
+
+This is the pattern already visible in the [acceptance tests](../basics/start-with-acceptance.md): `system.get_use_case(:create_light)`. The dependency factory is what makes that work.
+
+## The composition root
+
+The place where you construct the factory and wire everything together is called the composition root. In a Sinatra app this is typically the application file, before any routes are defined:
+
+```ruby
+def dependencies
+  @dependencies ||= Dependencies.new(db: DB)
+end
+```
+
+There is exactly one place in your codebase that knows about `SequelOrderGateway` and `DB`. Everything else is shielded from that knowledge.
+
+## Swapping implementations for tests
+
+Because all construction lives in the factory, you can create a test variant that injects fakes instead of real gateways — without changing any delivery mechanism code:
+
+```ruby
+class TestDependencies
+  def get_use_case(name)
+    case name
+    when :place_order
+      PlaceOrder.new(order_gateway: InMemoryOrderGateway.new, notifier: FakeNotifier.new)
+    when :list_orders
+      ListOrders.new(order_gateway: InMemoryOrderGateway.new)
+    end
+  end
+end
+```
+
+Your acceptance tests use `TestDependencies`. Your production app uses `Dependencies`. The use cases and delivery mechanisms never change.


### PR DESCRIPTION
## Summary

- Adds all 6 missing intermediate guides referenced in the README
- Builds on the basics guides — each guide references earlier concepts rather than re-explaining them
- Examples use the same lighting/orders domain established in the basics

## Guides added

| File | Title |
|------|-------|
| `learn/intermediate/flexible-presenters.md` | Presenters are more flexible |
| `learn/intermediate/keep-your-wiring-DRY.md` | Keep your wiring DRY |
| `learn/intermediate/extend-with-domain.md` | Extend Use Case behaviour with Domain objects |
| `learn/intermediate/extract-use-case-from-another.md` | Extracting a Use Case from a Use Case |
| `learn/intermediate/authentication.md` | Authentication |
| `learn/intermediate/authorisation.md` | Authorisation |

## Key decisions

- `keep-your-wiring-DRY` introduces the dependency factory pattern, which is what underpins `system.get_use_case(:name)` already seen in `start-with-acceptance.md`
- `extend-with-domain` grounds itself in the quote from `domain.md` about starting anemic and evolving toward generalisations
- `authentication` and `authorisation` are clearly separated — auth in the delivery mechanism before filter, authz as a policy domain object inside the use case
- Authorisation explicitly warns against putting rules in delivery mechanism `before` filters

## Test plan

- [ ] Read each guide for tone and consistency with existing guides
- [ ] Check all cross-references and internal links resolve
- [ ] Verify Ruby examples are syntactically correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)